### PR TITLE
Update to GeckoView Nightly 100.0.20220324093615 on main

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "100.0.20220310065911"
+    const val version = "100.0.20220324093615"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
This (automated) patch updates GV Nightly on main to 100.0.20220324093615.